### PR TITLE
Increase requests rate limit to 1500

### DIFF
--- a/src/middlewares/rateLimit.ts
+++ b/src/middlewares/rateLimit.ts
@@ -2,7 +2,7 @@ import rateLimit from "express-rate-limit";
 
 export const limiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 60 minutes
-  max: 50, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+  max: 1500, // Limit each IP to 1500 requests per `window` (here, per 60 minutes)
   standardHeaders: "draft-7", // Set `RateLimit` and `RateLimit-Policy`` headers
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
   message:


### PR DESCRIPTION
Increase the request rate limit to 1500 requests per hour.

* Update the `max` property in `src/middlewares/rateLimit.ts` from 50 to 1500.
* Ensure the `message` property remains the same. 

